### PR TITLE
[MDEP-809] - correct javadoc to reflect state of the -Dverbose option

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/tree/TreeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/tree/TreeMojo.java
@@ -157,9 +157,8 @@ public class TreeMojo
     private String scope;
 
     /**
-     * Whether to include omitted nodes in the serialized dependency tree. Notice this feature actually uses Maven 2
-     * algorithm and <a href="https://maven.apache.org/shared/maven-dependency-tree/">may give wrong results when used
-     * with Maven 3</a>.
+     * Whether to include omitted nodes in the serialized dependency tree. If specified, the whole dependency tree
+     * will be displayed, not only the resolved one. 
      *
      * @since 2.0-alpha-6
      */


### PR DESCRIPTION
while the verbose option was corrected a while ago, the javadoc still reflected its broken state.



To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)



